### PR TITLE
Increase CAS_LEN_NETID to 320 (email address max length)

### DIFF
--- a/sources/cas.h
+++ b/sources/cas.h
@@ -39,7 +39,7 @@
 #define DEFAULT_CONFIG_NAME     "/etc/pam_cas.conf"
 #define DEFAULT_URI_VALIDATE    "/proxyValidate"
 
-#define CAS_LEN_NETID          32
+#define CAS_LEN_NETID          320
 #define HTTP_1_1               // a commenter pour http 1.0
 
 


### PR DESCRIPTION
Hello, 

We used pam_cas for SSO with dovecot server. We use emails addresses as login. 
Email addresses longer than CAS_LEN_NETID will be truncate and login failed. 

320 is the limit for email addresse length defined in the RFC. 

