### PR TITLE
Update cas_validator.c

### DIFF
--- a/sources/cas_validator.c
+++ b/sources/cas_validator.c
@@ -79,7 +79,7 @@ int cas_validate(
   SSL_CTX *ctx = NULL;
   BIO * bio = NULL;
   SSL *ssl = NULL;
-  char buf[4096];
+  char buf[16384];
   char *full_request = NULL, *str;
   char netid[CAS_LEN_NETID];
   char parsebuf[128];


### PR DESCRIPTION
augmentation de la taille du buffer, limitante si les attributs retournés sont nombreux et/ou longs.